### PR TITLE
Added ability to choose only monospaced fonts

### DIFF
--- a/test.py
+++ b/test.py
@@ -62,6 +62,12 @@ class TestFontChooser(BaseWidgetTest):
                     text='Abcd' * 20, title='Test')
         self.window.update()
 
+    def test_fontchooser_init_only_fixed(self):
+        FontChooser(self.window,
+                    {'family': 'Arial', 'weight': 'bold', 'slant': 'italic'},
+                    text='Abcd' * 20, title='Test', only_fixed=True)
+        self.window.update()
+
     def test_fontchooser_methods(self):
         props = {'family': "TkDefaultFont", 'weight': 'bold', 'size': 27,
                  'slant': 'italic'}

--- a/tkfontchooser.py
+++ b/tkfontchooser.py
@@ -55,7 +55,7 @@ class FontChooser(Toplevel):
     """Font chooser dialog."""
 
     def __init__(self, master, font_dict={}, text="Abcd", title="Font Chooser",
-                 **kwargs):
+                 only_fixed=False, **kwargs):
         """
         Create a new FontChooser instance.
 
@@ -101,8 +101,17 @@ class FontChooser(Toplevel):
         self.configure(bg=bg)
 
         # --- family list
-        self.fonts = list(set(families()))
-        self.fonts.append("TkDefaultFont")
+        if only_fixed:
+            all_families = list(set(families()))
+            self.fonts = []
+            for ffamily in all_families:
+                fnt = Font(family=ffamily)
+                is_fixed = fnt.metrics('fixed')
+                if (is_fixed != 0):
+                    self.fonts.append(ffamily)
+        else:
+            self.fonts = list(set(families()))
+            self.fonts.append("TkDefaultFont")
         self.fonts.sort()
         for i in range(len(self.fonts)):
             self.fonts[i] = self.fonts[i].replace(" ", "\ ")


### PR DESCRIPTION
If 'only_fixed' parameter to FontChooser class constructor is set to
True then fonts families list is populated only with monospaced font
families.

Font list is filtered by font metric 'fixed'.